### PR TITLE
Gdt without data segment

### DIFF
--- a/src/arch/x86_64/boot.asm
+++ b/src/arch/x86_64/boot.asm
@@ -29,12 +29,6 @@ start:
 	; load the 64-bit GDT
 	lgdt [gdt64.pointer]
 
-	; update selectors
-	mov ax, gdt64.data
-	mov ss, ax	; stack selector
-	mov ds, ax	; data selector
-	mov es, ax	; extra selector
-
 	jmp gdt64.code:long_mode_start
 
 set_up_page_tables:
@@ -198,8 +192,6 @@ gdt64:
 	dq 0 ; zero entry
 .code: equ $ - gdt64
 	dq (1<<44) | (1<<47) | (1<<43) | (1<<53) ; code segment
-.data: equ $ - gdt64
-	dq (1<<44) | (1<<47) | (1<<41) ; data segment
 .pointer:
 	dw $ - gdt64 -1
 	dq gdt64

--- a/src/arch/x86_64/boot.asm
+++ b/src/arch/x86_64/boot.asm
@@ -197,7 +197,7 @@ section .rodata
 gdt64:
 	dq 0 ; zero entry
 .code: equ $ - gdt64
-	dq (1<<44) | (1<<47) | (1<<41) | (1<<43) | (1<<53) ; code segment
+	dq (1<<44) | (1<<47) | (1<<43) | (1<<53) ; code segment
 .data: equ $ - gdt64
 	dq (1<<44) | (1<<47) | (1<<41) ; data segment
 .pointer:

--- a/src/arch/x86_64/long_mode_init.asm
+++ b/src/arch/x86_64/long_mode_init.asm
@@ -16,6 +16,14 @@ extern main
 section .text
 bits 64
 long_mode_start:
+    ; load 0 into all data segment registers
+    mov ax, 0
+    mov ss, ax
+    mov ds, ax
+    mov es, ax
+    mov fs, ax
+    mov gs, ax
+
     ; call main.cr
     call main
 


### PR DESCRIPTION
#29 

- Remove ignored flag on 64-bit mode
- Remove data segment and selectors
- Instead, load 0 into all data segment registers in `long_mode_init`
