### PR TITLE
[Makefile] Make directories for object files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ $(crystal_os): $(crystal_files)
 				@mv -f main.o target/$(target)/debug/
 
 build/arch/$(arch)/%.o: src/arch/$(arch)/%.asm
+				@mkdir -p $(shell dirname $@)
 				@nasm -felf64 $< -o $@
 
 $(libcr):


### PR DESCRIPTION
It's my completely mistake.

I've never known git won't track an empty directory. We have to make ``arch/x86_64`` directories for object files when building like this.

```
build/
├── arch
│   └── x86_64
│       ├── boot.o
│       ├── long_mode_init.o
│       └── multiboot_header.o
```