### PR TITLE
Change target option to x86_64-unknown-linux-musl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 # https://github.com/phil-opp/blog_os/blob/set_up_rust/Makefile
 
 arch ?= x86_64
-target ?= $(arch)-pc-linux-gnu
+target ?= $(arch)-unknown-linux-musl
 kernel := build/kernel-$(arch).bin
 iso := build/utero-$(arch).iso
 

--- a/build/musl/Makefile
+++ b/build/musl/Makefile
@@ -5,7 +5,7 @@ BUILD_DIR = ..
 
 # -w Suppress all warnings
 MUSL_CFLAGS = -march=x86-64 -m64 -w
-MUSL_OPTION = --disable-shared
+MUSL_OPTION = --disable-shared --target=x86_64-unknown-linux-musl
 
 CC = clang
 


### PR DESCRIPTION
Introduced ``musl`` at #35 , so we changed the target options.
 