### PR TITLE
Fix broken tests

### DIFF
--- a/spec/lib_cr/ctype_spec.cr
+++ b/spec/lib_cr/ctype_spec.cr
@@ -8,7 +8,7 @@
 # except according to those terms.
 
 require "../spec_helper"
-require "../../src/lib_cr/ctype"
+require "../../src/core/lib_cr/x86_64-linux-musl/c/ctype"
 
 describe "LibCR" do
   describe "fun isalpha(c : Char) : Int" do

--- a/spec/lib_cr/string_spec.cr
+++ b/spec/lib_cr/string_spec.cr
@@ -8,7 +8,7 @@
 # except according to those terms.
 
 require "../spec_helper"
-require "../../src/lib_cr/string"
+require "../../src/core/lib_cr/x86_64-linux-musl/c/string"
 # FIXME: or KILLME
 # require "../../src/lib_cr/no_bind/libstring"
 # include NoBind


### PR DESCRIPTION
The error occurred such like this:

```
in spec/lib_cr/ctype_spec.cr:11: while requiring "../../src/lib_cr/ctype": can't find file '../../src/lib_cr/ctype' relative to '/home/noriyotcp/MyPlaygrounds/UteroOS/utero/spec/lib_cr'

require "../../src/lib_cr/ctype"
```

Fixed paths to require

It's hardcoding, but nevermind...
