### PR TITLE
Refactoring Scrn methods

### DIFF
--- a/src/kernel/scrn.cr
+++ b/src/kernel/scrn.cr
@@ -78,15 +78,6 @@ struct Scrn
     outb(0x3d5_u16, (temp >> 8).to_u8)
   end
 
-  def clear
-    attr = 0x0f.to_u16 << 8 | ' '.ord
-    VGA_SIZE.times { |i| @vmem[i] = attr }
-
-    @cur_x = 0
-    @cur_y = 0
-    update_cur
-  end
-
   private def linebreak
     @cur_x = 0
     @cur_y += 1
@@ -125,6 +116,15 @@ struct Scrn
     @vmem[@cur_y * VGA_WIDTH + @cur_x] = (@vga_color.to_u16 << 8 | byte).as(UInt16)
     @cur_x += 1
     linebreak if @cur_x == VGA_WIDTH
+    update_cur
+  end
+
+  def clear
+    attr = 0x0f.to_u16 << 8 | ' '.ord
+    VGA_SIZE.times { |i| @vmem[i] = attr }
+
+    @cur_x = 0
+    @cur_y = 0
     update_cur
   end
 

--- a/src/kernel/scrn.cr
+++ b/src/kernel/scrn.cr
@@ -140,7 +140,7 @@ struct Scrn
     str.each_byte { |byte| put_byte(byte) }
   end
 
-  def _cprint(buf)
+  def cprint(buf)
     len = LibCR.strlen(buf)
     len.times do |i|
       put_byte(buf[i])
@@ -168,7 +168,7 @@ def puts
 end
 
 def cprint(str : UInt8*)
-  SCRN._cprint(str)
+  SCRN.cprint(str)
 end
 
 def clear


### PR DESCRIPTION
- Change ``_cprint`` to ``cprint``

Is it needed to change top level methods such as ``puts`` or ``print`` to ``kputs`` or ``kprint``?
Hummmm, I will consider that later...