### PR TITLE
Implement idt isrs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # utero
-![utero screen 2017-04-08 15-02](https://cloud.githubusercontent.com/assets/5820754/24826288/203f250e-1c6d-11e7-9c0a-1eec88be3503.gif)
+![utero screenshot 2017-04-10 20-33](https://cloud.githubusercontent.com/assets/5820754/24860805/3ce9117c-1e31-11e7-8488-9c643c01d24b.gif)
 
 **Utero** is an operating system (for x86_64) written in [Crystal](https://crystal-lang.org/) *as much as possible*.
 

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -15,6 +15,9 @@ https://github.com/TheKernelCorp/NuummiteOS
 ### Cyanurus
 https://github.com/redcap97/cyanurus
 
+### eduOS
+https://github.com/RWTH-OS/eduOS
+
 -----
 
 ### Create Your Own Operating System: Build, deploy, and test your very own operating systems for the Internet of Things and other devices Kindle Edition

--- a/src/arch/x86_64/c/idt.c
+++ b/src/arch/x86_64/c/idt.c
@@ -1,0 +1,56 @@
+// Copyright (c) 2016-2017 Utero OS Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+//
+// The part of this file was taken from:
+// https://github.com/RWTH-OS/eduOS/blob/master/arch/x86/kernel/idt.c
+
+#include "idt.h"
+
+static idt_entry_t idt[256] = {[0 ... 255] = {0, 0, 0, 0, 0, 0, 0}};
+static idt_ptr_t idtp;
+
+void configure_idt_entry(idt_entry_t *dest_entry, size_t base,
+  unsigned short sel, unsigned char flags)
+{
+  /* The interrupt routine's base address */
+  dest_entry->base_lo = (base & 0xFFFF);
+  dest_entry->base_hi = (base >> 16) & 0xFFFF;
+
+  /* The segment or 'selector' that this IDT entry will use
+   *  is set here, along with any access flags */
+  dest_entry->sel = sel;
+  dest_entry->always0 = 0;
+  dest_entry->flags = flags;
+}
+
+/*
+ * Use this function to set an entry in the IDT. Alot simpler
+ * than twiddling with the GDT ;)
+ */
+void idt_set_gate(unsigned char num, size_t base, unsigned short sel,
+    unsigned char flags)
+{
+  configure_idt_entry(&idt[num], base, sel, flags);
+}
+
+/* Installs the IDT */
+void idt_install(void)
+{
+  static int initialized = 0;
+
+  if (!initialized) {
+    initialized = 1;
+
+    /* Sets the special IDT pointer up, just like in 'gdt.c' */
+    idtp.limit = (sizeof(idt_entry_t) * 256) - 1;
+    idtp.base = (size_t)&idt;
+  }
+  /* Points the processor's internal register to the new IDT */
+  asm volatile("lidt %0" : : "m" (idtp));
+}

--- a/src/arch/x86_64/c/idt.h
+++ b/src/arch/x86_64/c/idt.h
@@ -15,6 +15,33 @@
 
 #include "stddef.h"
 
+// This bit shall be set to 0 if the IDT slot is empty
+#define IDT_FLAG_PRESENT 	0x80
+// Interrupt can be called from within RING0
+#define IDT_FLAG_RING0		0x00
+// Interrupt can be called from within RING1 and lower
+#define IDT_FLAG_RING1		0x20
+// Interrupt can be called from within RING2 and lower
+#define IDT_FLAG_RING2		0x40
+// Interrupt can be called from within RING3 and lower
+#define IDT_FLAG_RING3		0x60
+// Size of gate is 16 bit
+#define IDT_FLAG_16BIT		0x00
+// Size of gate is 32 bit
+#define IDT_FLAG_32BIT		0x08
+// The entry describes an interrupt gate
+#define IDT_FLAG_INTTRAP	0x06
+// The entry describes a trap gate
+#define IDT_FLAG_TRAPGATE	0x07
+// The entry describes a task gate
+#define IDT_FLAG_TASKGATE	0x05
+
+/*
+ * This is not IDT-flag related. It's the segment selectors for kernel code and data.
+ */
+#define KERNEL_CODE_SELECTOR	0x08
+#define KERNEL_DATA_SELECTOR	0x10
+
 typedef struct {
   // Handler function's lower 16 address bits
   uint16_t base_lo;
@@ -33,9 +60,9 @@ typedef struct {
 } __attribute__ ((packed)) idt_entry_t;
 
 typedef struct {
-  /// Size of the IDT in bytes (not the number of entries!)
+  // Size of the IDT in bytes (not the number of entries!)
   uint16_t limit;
-  /// Base address of the IDT
+  // Base address of the IDT
   size_t base;
 } __attribute__ ((packed)) idt_ptr_t;
 

--- a/src/arch/x86_64/c/idt.h
+++ b/src/arch/x86_64/c/idt.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2016-2017 Utero OS Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+//
+// The part of this file was taken from:
+// https://github.com/RWTH-OS/eduOS/blob/master/arch/x86/include/asm/idt.h
+
+#ifndef IDT_H
+#define IDT_H
+
+#include "stddef.h"
+
+typedef struct {
+  // Handler function's lower 16 address bits
+  uint16_t base_lo;
+  // Handler function's segment selector.
+  uint16_t sel;
+  // These bits are reserved by Intel
+  uint8_t always0;
+  // These 8 bits contain flags. Exact use depends on the type of interrupt gate.
+  uint8_t flags;
+  // Higher 16 bits of handler function's base address
+  uint16_t base_hi;
+  // In 64 bit mode, the "highest" 32 bits of the handler function's base address
+  uint32_t base_hi64;
+  // reserved entries
+  uint32_t reserved;
+} __attribute__ ((packed)) idt_entry_t;
+
+typedef struct {
+  /// Size of the IDT in bytes (not the number of entries!)
+  uint16_t limit;
+  /// Base address of the IDT
+  size_t base;
+} __attribute__ ((packed)) idt_ptr_t;
+
+void idt_install(void);
+
+void idt_set_gate(unsigned char num, size_t base, unsigned short sel,
+      unsigned char flags);
+
+void configure_idt_entry(idt_entry_t *dest_entry, size_t base,
+      unsigned short sel, unsigned char flags);
+
+#endif /* end of include guard: IDT_H */

--- a/src/arch/x86_64/c/io.h
+++ b/src/arch/x86_64/c/io.h
@@ -1,0 +1,20 @@
+// Copyright (c) 2016-2017 Utero OS Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+//
+// Functions are taken from musl/arch/x86_64/bits/io.h
+
+#ifndef IO_H
+#define IO_H
+
+static __inline void outb(unsigned char __val, unsigned short __port)
+{
+	__asm__ volatile ("outb %0,%1" : : "a" (__val), "dN" (__port));
+}
+
+#endif /* end of include guard: IO_H */

--- a/src/arch/x86_64/c/isrs.c
+++ b/src/arch/x86_64/c/isrs.c
@@ -1,0 +1,189 @@
+// Copyright (c) 2016-2017 Utero OS Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+//
+// The part of this file was taken from:
+// https://github.com/RWTH-OS/eduOS/blob/master/arch/x86/kernel/isrs.c
+
+#include "idt.h"
+#include "isrs.h"
+#include "io.h"
+#include "stdio.h"
+
+/*
+ * These are function prototypes for all of the exception
+ * handlers: The first 32 entries in the IDT are reserved
+ * by Intel and are designed to service exceptions!
+ */
+extern void isr0(void);
+extern void isr1(void);
+extern void isr2(void);
+extern void isr3(void);
+extern void isr4(void);
+extern void isr5(void);
+extern void isr6(void);
+extern void isr7(void);
+extern void isr8(void);
+extern void isr9(void);
+extern void isr10(void);
+extern void isr11(void);
+extern void isr12(void);
+extern void isr13(void);
+extern void isr14(void);
+extern void isr15(void);
+extern void isr16(void);
+extern void isr17(void);
+extern void isr18(void);
+extern void isr19(void);
+extern void isr20(void);
+extern void isr21(void);
+extern void isr22(void);
+extern void isr23(void);
+extern void isr24(void);
+extern void isr25(void);
+extern void isr26(void);
+extern void isr27(void);
+extern void isr28(void);
+extern void isr29(void);
+extern void isr30(void);
+extern void isr31(void);
+extern int eputs(const char *);
+extern int eprint(const char *);
+
+void fault_handler(struct state *s);
+// static void fault_handler(struct state *s);
+// fqu_handler
+
+/*
+ * This is a very repetitive function... it's not hard, it's
+ * just annoying. As you can see, we set the first 32 entries
+ * in the IDT to the first 32 ISRs. We can't use a for loop
+ * for this, because there is no way to get the function names
+ * that correspond to that given entry. We set the access
+ * flags to 0x8E. This means that the entry is present, is
+ * running in ring 0 (kernel level), and has the lower 5 bits
+ * set to the required '14', which is represented by 'E' in
+ * hex.
+ */
+void isrs_install(void)
+{
+  int i;
+
+  idt_set_gate(0, (size_t)isr0, KERNEL_CODE_SELECTOR,
+  IDT_FLAG_PRESENT|IDT_FLAG_RING0|IDT_FLAG_32BIT|IDT_FLAG_INTTRAP);
+  idt_set_gate(1, (size_t)isr1, KERNEL_CODE_SELECTOR,
+  IDT_FLAG_PRESENT|IDT_FLAG_RING0|IDT_FLAG_32BIT|IDT_FLAG_INTTRAP);
+  idt_set_gate(2, (size_t)isr2, KERNEL_CODE_SELECTOR,
+  IDT_FLAG_PRESENT|IDT_FLAG_RING0|IDT_FLAG_32BIT|IDT_FLAG_INTTRAP);
+  idt_set_gate(3, (size_t)isr3, KERNEL_CODE_SELECTOR,
+  IDT_FLAG_PRESENT|IDT_FLAG_RING0|IDT_FLAG_32BIT|IDT_FLAG_INTTRAP);
+  idt_set_gate(4, (size_t)isr4, KERNEL_CODE_SELECTOR,
+  IDT_FLAG_PRESENT|IDT_FLAG_RING0|IDT_FLAG_32BIT|IDT_FLAG_INTTRAP);
+  idt_set_gate(5, (size_t)isr5, KERNEL_CODE_SELECTOR,
+  IDT_FLAG_PRESENT|IDT_FLAG_RING0|IDT_FLAG_32BIT|IDT_FLAG_INTTRAP);
+  idt_set_gate(6, (size_t)isr6, KERNEL_CODE_SELECTOR,
+  IDT_FLAG_PRESENT|IDT_FLAG_RING0|IDT_FLAG_32BIT|IDT_FLAG_INTTRAP);
+  idt_set_gate(7, (size_t)isr7, KERNEL_CODE_SELECTOR,
+  IDT_FLAG_PRESENT|IDT_FLAG_RING0|IDT_FLAG_32BIT|IDT_FLAG_INTTRAP);
+  idt_set_gate(8, (size_t)isr8, KERNEL_CODE_SELECTOR,
+  IDT_FLAG_PRESENT|IDT_FLAG_RING0|IDT_FLAG_32BIT|IDT_FLAG_INTTRAP);
+  idt_set_gate(9, (size_t)isr9, KERNEL_CODE_SELECTOR,
+  IDT_FLAG_PRESENT|IDT_FLAG_RING0|IDT_FLAG_32BIT|IDT_FLAG_INTTRAP);
+  idt_set_gate(10, (size_t)isr10, KERNEL_CODE_SELECTOR,
+  IDT_FLAG_PRESENT|IDT_FLAG_RING0|IDT_FLAG_32BIT|IDT_FLAG_INTTRAP);
+  idt_set_gate(11, (size_t)isr11, KERNEL_CODE_SELECTOR,
+  IDT_FLAG_PRESENT|IDT_FLAG_RING0|IDT_FLAG_32BIT|IDT_FLAG_INTTRAP);
+  idt_set_gate(12, (size_t)isr12, KERNEL_CODE_SELECTOR,
+  IDT_FLAG_PRESENT|IDT_FLAG_RING0|IDT_FLAG_32BIT|IDT_FLAG_INTTRAP);
+  idt_set_gate(13, (size_t)isr13, KERNEL_CODE_SELECTOR,
+   IDT_FLAG_PRESENT|IDT_FLAG_RING0|IDT_FLAG_32BIT|IDT_FLAG_INTTRAP);
+  idt_set_gate(14, (size_t)isr14, KERNEL_CODE_SELECTOR,
+  IDT_FLAG_PRESENT|IDT_FLAG_RING0|IDT_FLAG_32BIT|IDT_FLAG_INTTRAP);
+  idt_set_gate(15, (size_t)isr15, KERNEL_CODE_SELECTOR,
+  IDT_FLAG_PRESENT|IDT_FLAG_RING0|IDT_FLAG_32BIT|IDT_FLAG_INTTRAP);
+  idt_set_gate(16, (size_t)isr16, KERNEL_CODE_SELECTOR,
+  IDT_FLAG_PRESENT|IDT_FLAG_RING0|IDT_FLAG_32BIT|IDT_FLAG_INTTRAP);
+  idt_set_gate(17, (size_t)isr17, KERNEL_CODE_SELECTOR,
+  IDT_FLAG_PRESENT|IDT_FLAG_RING0|IDT_FLAG_32BIT|IDT_FLAG_INTTRAP);
+  idt_set_gate(18, (size_t)isr18, KERNEL_CODE_SELECTOR,
+  IDT_FLAG_PRESENT|IDT_FLAG_RING0|IDT_FLAG_32BIT|IDT_FLAG_INTTRAP);
+  idt_set_gate(19, (size_t)isr19, KERNEL_CODE_SELECTOR,
+  IDT_FLAG_PRESENT|IDT_FLAG_RING0|IDT_FLAG_32BIT|IDT_FLAG_INTTRAP);
+  idt_set_gate(20, (size_t)isr20, KERNEL_CODE_SELECTOR,
+  IDT_FLAG_PRESENT|IDT_FLAG_RING0|IDT_FLAG_32BIT|IDT_FLAG_INTTRAP);
+  idt_set_gate(21, (size_t)isr21, KERNEL_CODE_SELECTOR,
+  IDT_FLAG_PRESENT|IDT_FLAG_RING0|IDT_FLAG_32BIT|IDT_FLAG_INTTRAP);
+  idt_set_gate(22, (size_t)isr22, KERNEL_CODE_SELECTOR,
+  IDT_FLAG_PRESENT|IDT_FLAG_RING0|IDT_FLAG_32BIT|IDT_FLAG_INTTRAP);
+  idt_set_gate(23, (size_t)isr23, KERNEL_CODE_SELECTOR,
+  IDT_FLAG_PRESENT|IDT_FLAG_RING0|IDT_FLAG_32BIT|IDT_FLAG_INTTRAP);
+  idt_set_gate(24, (size_t)isr24, KERNEL_CODE_SELECTOR,
+  IDT_FLAG_PRESENT|IDT_FLAG_RING0|IDT_FLAG_32BIT|IDT_FLAG_INTTRAP);
+  idt_set_gate(25, (size_t)isr25, KERNEL_CODE_SELECTOR,
+  IDT_FLAG_PRESENT|IDT_FLAG_RING0|IDT_FLAG_32BIT|IDT_FLAG_INTTRAP);
+  idt_set_gate(26, (size_t)isr26, KERNEL_CODE_SELECTOR,
+  IDT_FLAG_PRESENT|IDT_FLAG_RING0|IDT_FLAG_32BIT|IDT_FLAG_INTTRAP);
+  idt_set_gate(27, (size_t)isr27, KERNEL_CODE_SELECTOR,
+  IDT_FLAG_PRESENT|IDT_FLAG_RING0|IDT_FLAG_32BIT|IDT_FLAG_INTTRAP);
+  idt_set_gate(28, (size_t)isr28, KERNEL_CODE_SELECTOR,
+  IDT_FLAG_PRESENT|IDT_FLAG_RING0|IDT_FLAG_32BIT|IDT_FLAG_INTTRAP);
+  idt_set_gate(29, (size_t)isr29, KERNEL_CODE_SELECTOR,
+  IDT_FLAG_PRESENT|IDT_FLAG_RING0|IDT_FLAG_32BIT|IDT_FLAG_INTTRAP);
+  idt_set_gate(30, (size_t)isr30, KERNEL_CODE_SELECTOR,
+  IDT_FLAG_PRESENT|IDT_FLAG_RING0|IDT_FLAG_32BIT|IDT_FLAG_INTTRAP);
+  idt_set_gate(31, (size_t)isr31, KERNEL_CODE_SELECTOR,
+  IDT_FLAG_PRESENT|IDT_FLAG_RING0|IDT_FLAG_32BIT|IDT_FLAG_INTTRAP);
+
+  // install the default handler
+
+  // set hanlder for fpu exceptions
+}
+
+/** @brief Exception messages
+ *
+ * This is a simple string array. It contains the message that
+ * corresponds to each and every exception. We get the correct
+ * message by accessing it like this:
+ * exception_message[interrupt_number]
+ */
+static const char *exception_messages[] = {
+  "Division By Zero", "Debug", "Non Maskable Interrupt",
+  "Breakpoint", "Into Detected Overflow", "Out of Bounds", "Invalid Opcode",
+  "No Coprocessor", "Double Fault", "Coprocessor Segment Overrun", "Bad TSS",
+  "Segment Not Present", "Stack Fault", "General Protection Fault", "Page Fault",
+  "Unknown Interrupt", "Coprocessor Fault", "Alignment Check", "Machine Check",
+  "Reserved", "Reserved", "Reserved", "Reserved", "Reserved",
+  "Reserved", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved",
+  "Reserved", "Reserved" };
+
+  /*
+   * All of our Exception handling Interrupt Service Routines will
+   * point to this function. This will tell us what exception has
+   * occured! Right now, we simply abort the current task.
+   * All ISRs disable interrupts while they are being
+   * serviced as a 'locking' mechanism to prevent an IRQ from
+   * happening and messing up kernel data structures
+   */
+#define N 256
+void fault_handler(struct state *s)
+// static void fault_handler(struct state *s)
+{
+  char message[N] = {'\0'};
+  if (s->int_no < 32) {
+  sprintf(message, " Exception (%llu) at 0x%llx:0x%llx, error code 0x%llx, rflags 0x%llx\n",
+    s->int_no, s->cs, s->rip, s->error, s->rflags);
+  eputs(exception_messages[s->int_no]);
+  eprint(message);
+
+  outb(0x20, 0x20);
+
+  // irq_enable();
+  // abort();
+    for (;;);
+  }
+}

--- a/src/arch/x86_64/c/isrs.h
+++ b/src/arch/x86_64/c/isrs.h
@@ -1,0 +1,20 @@
+// Copyright (c) 2016-2017 Utero OS Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+//
+// The part of this file was taken from:
+// https://github.com/RWTH-OS/eduOS/blob/master/arch/x86/include/asm/isrs.h
+
+#ifndef ISRS_H
+#define ISRS_H
+
+#include "stddef.h"
+
+void isrs_install(void);
+
+#endif /* end of include guard: ISRS_H */

--- a/src/arch/x86_64/c/stddef.h
+++ b/src/arch/x86_64/c/stddef.h
@@ -33,4 +33,51 @@ typedef char int8_t;
 // A popular type for addresses
 typedef unsigned long long size_t;
 
+// This defines what the stack looks like after the task context is saved.
+struct state {
+  // R15 register
+  uint64_t r15;
+  // R14 register
+  uint64_t r14;
+  // R13 register
+  uint64_t r13;
+  // R12 register
+  uint64_t r12;
+  // R11 register
+  uint64_t r11;
+  // R10 register
+  uint64_t r10;
+  // R9 register
+  uint64_t r9;
+  // R8 register
+  uint64_t r8;
+  // RDI register
+  uint64_t rdi;
+  // RSI register
+  uint64_t rsi;
+  // RBP register
+  uint64_t rbp;
+  // (pseudo) RSP register
+  uint64_t rsp;
+  // RBX register
+  uint64_t rbx;
+  // RDX register
+  uint64_t rdx;
+  // RCX register
+  uint64_t rcx;
+  // RAX register
+  uint64_t rax;
+
+  // Interrupt number
+  uint64_t int_no;
+
+  // pushed by the processor automatically
+  uint64_t error;
+  uint64_t rip;
+  uint64_t cs;
+  uint64_t rflags;
+  uint64_t userrsp;
+  uint64_t ss;
+};
+
 #endif /* end of include guard: STDDEF_H */

--- a/src/arch/x86_64/c/stddef.h
+++ b/src/arch/x86_64/c/stddef.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2016-2017 Utero OS Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+//
+// The part of this file was taken from:
+// https://github.com/RWTH-OS/eduOS/blob/master/arch/x86/include/asm/stddef.h
+
+#ifndef STDDEF_H
+#define STDDEF_H
+
+// Unsigned 64 bit integer
+typedef unsigned long long uint64_t;
+// Signed 64 bit integer
+typedef long long int64_t;
+// Unsigned 32 bit integer
+typedef unsigned int uint32_t;
+// Signed 32 bit integer
+typedef int int32_t;
+// Unsigned 16 bit integer
+typedef unsigned short uint16_t;
+// Signed 16 bit integer
+typedef short int16_t;
+// Unsigned 8 bit integer (/char)
+typedef unsigned char uint8_t;
+// Signed 8 bit integer (/char)
+typedef char int8_t;
+
+// A popular type for addresses
+typedef unsigned long long size_t;
+
+#endif /* end of include guard: STDDEF_H */

--- a/src/arch/x86_64/c/stdio.h
+++ b/src/arch/x86_64/c/stdio.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2017 Utero OS Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+//
+// Functions are taken from musl/include/stdio.h
+
+#ifndef STDIO_H
+#define STDIO_H
+
+int sprintf(char *__restrict, const char *__restrict, ...);
+
+#endif /* end of include guard: STDIO_H */

--- a/src/arch/x86_64/long_mode_init.asm
+++ b/src/arch/x86_64/long_mode_init.asm
@@ -9,30 +9,152 @@
 ;
 ; The part of this file was taken from:
 ; https://github.com/phil-opp/blog_os/blob/set_up_rust/src/arch/x86_64/long_mode_init.asm
+; https://github.com/RWTH-OS/eduOS/blob/master/arch/x86/kernel/entry.asm
 
 global long_mode_start
-extern main
 
 section .text
 bits 64
 long_mode_start:
-    ; load 0 into all data segment registers
-    mov ax, 0
-    mov ss, ax
-    mov ds, ax
-    mov es, ax
-    mov fs, ax
-    mov gs, ax
+	; load 0 into all data segment registers
+	mov ax, 0
+	mov ss, ax
+	mov ds, ax
+	mov es, ax
+	mov fs, ax
+	mov gs, ax
 
-    ; call main.cr
-    call main
+	extern idt_install
+	call idt_install
+	extern isrs_install
+	call isrs_install
+	; call main.cr
+	extern main
+	call main
 
-.os_returned:
-    ; crystal main returned, print `OS returned!`
-    ; mov rax, 0x4f724f204f534f4f
-    ; mov [0xb8000], rax
-    ; mov rax, 0x4f724f754f744f65
-    ; mov [0xb8008], rax
-    ; mov rax, 0x4f214f644f654f6e
-    ; mov [0xb8010], rax
-    hlt
+	; jmp $
+	hlt
+
+; The first 32 interrupt service routines (ISR) entries correspond to exceptions.
+; Some exceptions will push an error code onto the stack which is specific to
+; the exception caused. To decrease the complexity, we handle this by pushing a
+; Dummy error code of 0 onto the stack for any ISR that doesn't push an error
+; code already.
+;
+; ISRs are registered as "Interrupt Gate".
+; Therefore, the interrupt flag (IF) is already cleared.
+
+; NASM macro which pushs also an pseudo error code
+%macro isrstub_pseudo_error 1
+	global isr%1
+	isr%1:
+		push byte 0 ; pseudo error code
+		push byte %1
+		jmp common_stub
+%endmacro
+
+; Similar to isrstub_pseudo_error, but without pushing
+; a pseudo error code => The error code is already
+; on the stack.
+%macro isrstub 1
+	global isr%1
+	isr%1:
+		push byte %1
+		jmp common_stub
+%endmacro
+
+; Create isr entries, where the number after the
+; pseudo error code represents following interrupts:
+; 0: Divide By Zero Exception
+; 1: Debug Exception
+; 2: Non Maskable Interrupt Exception
+; 3: Int 3 Exception
+; 4: INTO Exception
+; 5: Out of Bounds Exception
+; 6: Invalid Opcode Exception
+; 7: Coprocessor Not Available Exception
+%assign i 0
+%rep    8
+	isrstub_pseudo_error i
+%assign i i+1
+%endrep
+
+; 8: Double Fault Exception (With Error Code!)
+isrstub 8
+
+; 9: Coprocessor Segment Overrun Exception
+isrstub_pseudo_error 9
+
+; 10: Bad TSS Exception (With Error Code!)
+; 11: Segment Not Present Exception (With Error Code!)
+; 12: Stack Fault Exception (With Error Code!)
+; 13: General Protection Fault Exception (With Error Code!)
+; 14: Page Fault Exception (With Error Code!)
+%assign i 10
+%rep 5
+	isrstub i
+%assign i i+1
+%endrep
+
+; 15: Reserved Exception
+; 16: Floating Point Exception
+; 17: Alignment Check Exception
+; 18: Machine Check Exceptio
+; 19-31: Reserved
+%assign i 15
+%rep    17
+	isrstub_pseudo_error i
+%assign i i+1
+%endrep
+
+extern fault_handler
+; extern irq_handler
+
+ALIGN 8
+common_stub:
+	push rax
+	push rcx
+	push rdx
+	push rbx
+	push rsp
+	push rbp
+	push rsi
+	push rdi
+	push r8
+	push r9
+	push r10
+	push r11
+	push r12
+	push r13
+	push r14
+	push r15
+
+	; use the same handler for interrupts and exceptions
+	mov rdi, rsp
+	call fault_handler
+	; call irq_handler
+
+	; cmp rax, 0
+	; je no_context_switch
+	jmp no_context_switch
+
+no_context_switch:
+	pop r15
+	pop r14
+	pop r13
+	pop r12
+	pop r11
+	pop r10
+	pop r9
+	pop r8
+	pop rdi
+	pop rsi
+	pop rbp
+	add rsp, 8
+	pop rbx
+	pop rdx
+	pop rcx
+	pop rax
+
+	add rsp, 16
+	iretq

--- a/src/kernel/lib_u/x86_64-linux-musl/c/idt.cr
+++ b/src/kernel/lib_u/x86_64-linux-musl/c/idt.cr
@@ -1,0 +1,14 @@
+# Copyright (c) 2016-2017 Utero OS Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+require "../../../lib_u"
+
+# idt.c
+lib LibU
+  fun idt_install : Void
+end

--- a/src/kernel/lib_u/x86_64-linux-musl/c/isrs.cr
+++ b/src/kernel/lib_u/x86_64-linux-musl/c/isrs.cr
@@ -1,0 +1,14 @@
+# Copyright (c) 2016-2017 Utero OS Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+require "../../../lib_u"
+
+# isrs.c
+lib LibU
+  fun isrs_install : Void
+end

--- a/src/kernel/main.cr
+++ b/src/kernel/main.cr
@@ -11,6 +11,9 @@ require "../core/prelude"
 require "./prelude"
 require "./scrn"
 
+# LibU.idt_install
+# LibU.isrs_install
+
 puts "1:"
 puts "2:"
 puts "3:"
@@ -51,6 +54,8 @@ print "\b"; puts
 puts "33: Current directory is #{__DIR__}"
 print "34: "; cprint(LibU.hello_from_c)
 cprint(LibU.dummy_exception)
+# Division By Zero
+42 / 0
 # clear
 
 # puts "---------strlen------------"

--- a/src/kernel/scrn.cr
+++ b/src/kernel/scrn.cr
@@ -171,6 +171,17 @@ def cprint(str : UInt8*)
   SCRN.cprint(str)
 end
 
+# Displays error messages from C with linebreak
+fun eputs(str : UInt8*)
+  SCRN.cprint(str)
+  puts
+end
+
+# Displays error messages from C
+fun eprint(str : UInt8*)
+  SCRN.cprint(str)
+end
+
 def clear
   SCRN.clear
 end


### PR DESCRIPTION
I know it's not perfect, but I can display error messages (Division By Zero) like this:

![utero screenshot 2017-04-10 20-33](https://cloud.githubusercontent.com/assets/5820754/24860805/3ce9117c-1e31-11e7-8488-9c643c01d24b.gif)


I referenced to eduOS's branch stage3.

stage3 - Preemptive multitasking

Introduction into preemptive multitasking and interrupt handling

https://github.com/RWTH-OS/eduOS/tree/stage3

But ``stage1`` and ``stage2`` have features those I've not implemented.

> stage1 - Non-preemptive multitasking
>
> Introduction into a simple form of multitasking, where no interrupts are required.
>
> stage2 - Synchronisation primitives
>
> Description of basic synchronization primitives

So long and winding road......
