### PR TITLE
Call idt_install and isrs_install from Crystal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 *.iso
 *.log
 *.a
+
+# vscode config
+.vscode/

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ $(iso): $(kernel) $(grub_cfg)
 				@grub-mkrescue -o $(iso) build/isofiles 2> /dev/null
 				@rm -r build/isofiles
 
-$(kernel): $(linker_script) $(libcr) $(libu) $(crystal_os) $(assembly_object_files)
+$(kernel): $(linker_script) $(libcr) $(libu) $(crystal_os)
 				@echo Creating $@...
 				@ld -n -nostdlib -melf_$(arch) --gc-sections --build-id=none -T $(linker_script) -o $@ $(assembly_object_files) $(crystal_os) $(libu) $(libcr)
 
@@ -66,15 +66,15 @@ $(crystal_os): $(libu) $(crystal_files)
 				@rm main
 				@mv -f main.o target/$(target)/debug/
 
-build/arch/$(arch)/%.o: src/arch/$(arch)/%.asm
-				@mkdir -p $(shell dirname $@)
-				@nasm -felf64 $< -o $@
-
 $(libcr):
 				$(MAKE) -C build/musl
 
-$(libu): $(c_object_files)
-				@ar r $(libu) $(c_object_files)
+$(libu): $(assembly_object_files) $(c_object_files)
+				@ar r $(libu) $(assembly_object_files) $(c_object_files)
+
+build/arch/$(arch)/%.o: src/arch/$(arch)/%.asm
+				@mkdir -p $(shell dirname $@)
+				@nasm -felf64 $< -o $@
 
 build/arch/$(arch)/c/%.o: src/arch/$(arch)/c/%.c
 				@mkdir -p $(shell dirname $@)

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ kernel := build/kernel-$(arch).bin
 iso := build/utero-$(arch).iso
 
 libcr := src/musl/lib/libcr.a
-libu = build/arch/$(arch)/c/libu.a
-libu_fullpath = $(subst build/,$(shell pwd)/build/,$(libu))
+libu := build/arch/$(arch)/c/libu.a
+libu_fullpath := $(subst build/,$(shell pwd)/build/,$(libu))
 c_source_files := $(wildcard src/arch/$(arch)/c/*.c)
 c_object_files := $(patsubst src/arch/$(arch)/c/%.c, \
 				build/arch/$(arch)/c/%.o, $(c_source_files))

--- a/src/arch/x86_64/long_mode_init.asm
+++ b/src/arch/x86_64/long_mode_init.asm
@@ -24,10 +24,6 @@ long_mode_start:
 	mov fs, ax
 	mov gs, ax
 
-	; extern idt_install
-	; call idt_install
-	; extern isrs_install
-	; call isrs_install
 	; These following lines call main.cr
 	extern main
 	call main

--- a/src/arch/x86_64/long_mode_init.asm
+++ b/src/arch/x86_64/long_mode_init.asm
@@ -24,11 +24,11 @@ long_mode_start:
 	mov fs, ax
 	mov gs, ax
 
-	extern idt_install
-	call idt_install
-	extern isrs_install
-	call isrs_install
-	; call main.cr
+	; extern idt_install
+	; call idt_install
+	; extern isrs_install
+	; call isrs_install
+	; These following lines call main.cr
 	extern main
 	call main
 

--- a/src/arch/x86_64/long_mode_init.asm
+++ b/src/arch/x86_64/long_mode_init.asm
@@ -17,7 +17,7 @@ section .text
 bits 64
 long_mode_start:
 	; load 0 into all data segment registers
-	mov ax, 0
+	xor ax, ax
 	mov ss, ax
 	mov ds, ax
 	mov es, ax

--- a/src/kernel/main.cr
+++ b/src/kernel/main.cr
@@ -9,10 +9,8 @@
 
 require "../core/prelude"
 require "./prelude"
+require "./utero_init"
 require "./scrn"
-
-LibU.idt_install
-LibU.isrs_install
 
 puts "1:"
 puts "2:"

--- a/src/kernel/main.cr
+++ b/src/kernel/main.cr
@@ -11,8 +11,8 @@ require "../core/prelude"
 require "./prelude"
 require "./scrn"
 
-# LibU.idt_install
-# LibU.isrs_install
+LibU.idt_install
+LibU.isrs_install
 
 puts "1:"
 puts "2:"

--- a/src/kernel/utero_init.cr
+++ b/src/kernel/utero_init.cr
@@ -1,0 +1,2 @@
+LibU.idt_install
+LibU.isrs_install


### PR DESCRIPTION
Tried to call ``idt_install`` and ``isrs_install`` through LibU, the error occurred

```sh
isrs.c:(.text+0x20): undefined reference to `isr0'
# Also undefined reference to `isr1'
...
```

``isr(n)`` are defined in assembly. So archived assembly object files into ``libu.a``.
